### PR TITLE
Allow to configure scanner multicast group, listening IP and ports

### DIFF
--- a/src/gradar_pi.h
+++ b/src/gradar_pi.h
@@ -419,6 +419,10 @@ private:
      void CacheSetToolbarToolBitmaps(int bm_id_normal, int bm_id_rollover);
 
      wxString         m_scanner_ip;
+     wxString         m_scanner_port;
+     wxString         m_multicast_group;
+     wxString         m_multicast_port;
+
      wxFileConfig     *m_pconfig;
      wxWindow         *m_parent_window;
      wxMenu           *m_pmenu;


### PR DESCRIPTION
Configuration is through opencpn.conf/ini, setting the keys ScannerIP, ScannerPort, MulticastGroup & MulticastPort.
I use this changes to set different simulation engines that send radar data to OpenCPN, allowing them to emit and answer at different addresses, being OpenCPN.